### PR TITLE
Added cluster state config file. 

### DIFF
--- a/tn_generative/data_configs/cluster_state_data_config.py
+++ b/tn_generative/data_configs/cluster_state_data_config.py
@@ -5,9 +5,7 @@ import numpy as np
 from ml_collections import config_dict
 
 home = os.path.expanduser('~')
-
-
-task_name = 'cluster_state'
+DEFAULT_TASK_NAME = 'cluster_state'
 
 
 def sweep_param_fn(system_size, d, onsite_z_field, sampler):
@@ -17,13 +15,13 @@ def sweep_param_fn(system_size, d, onsite_z_field, sampler):
       'task.kwargs.size_y': system_size,
       'dmrg.bond_dims': d,
       'task.kwargs.onsite_z_field': onsite_z_field,
-      'output.filename':  '_'.join(['%JOB_ID', task_name, sampler,
+      'output.filename':  '_'.join(['%JOB_ID', DEFAULT_TASK_NAME, sampler,
           f'{system_size=}', f'{d=}', f'{onsite_z_field=:.3f}']),
   }
 
 
 def sweep_sc_3x3_fn():
-  # 3x3 sites surface code sweep
+  # 3x3 sites cluster state sweep
   for system_size in [3]:
     for d in [10, 20]:
       for onsite_z_field in np.linspace(0., 0.2, 11):
@@ -58,7 +56,7 @@ def sweep_sc_7x7_fn():
           yield sweep_param_fn(system_size, d, onsite_z_field, sampler)
 
 
-sweep_fn_dict = {
+SWEEP_FN_REGISTRY = {
     "sweep_sc_3x3_fn": list(sweep_sc_3x3_fn()),
     "sweep_sc_5x5_fn": list(sweep_sc_5x5_fn()),
     "sweep_sc_7x7_fn": list(sweep_sc_7x7_fn())
@@ -71,11 +69,11 @@ def get_config():
   # Task configuration.
   config.dtype = 'complex128'
   config.task = config_dict.ConfigDict()
-  config.task.name = task_name
+  config.task.name = DEFAULT_TASK_NAME
   config.task.kwargs = {'size_x': 3, 'size_y': 3, 'onsite_z_field':0.}
   # sweep parameters.
   config.sweep_name = "sweep_sc_3x3_fn"  # Could change this in slurm script
-  config.sweep_fn_dict = sweep_fn_dict
+  config.sweep_fn_registry = SWEEP_FN_REGISTRY
   # DMRG configuration.
   config.dmrg = config_dict.ConfigDict()
   config.dmrg.bond_dims = 20

--- a/tn_generative/run_data_generation.py
+++ b/tn_generative/run_data_generation.py
@@ -27,13 +27,13 @@ TASK_REGISTRY = data_generation.TASK_REGISTRY
 
 
 def generate_data(config):
-  if config.sweep_name in config.sweep_fn_dict.keys():
-    sweep_param = config.sweep_fn_dict[config.sweep_name]
+  if config.sweep_name in config.sweep_fn_registry:
+    sweep_param = config.sweep_fn_registry[config.sweep_name]
     config.update_from_flattened_dict(sweep_param[config.task_id])
-  elif config.sweep_name == None:
+  elif config.sweep_name is None:
     pass
   else:
-    raise ValueError(f'{config.sweep_name} not in sweep_fn_dict.')
+    raise ValueError(f'{config.sweep_name} not in sweep_fn_registry.')
   current_date = datetime.now().strftime('%m%d')
   dtype = DTYPES_REGISTRY[config.dtype]
   task_system = TASK_REGISTRY[config.task.name](**config.task.kwargs)
@@ -46,6 +46,7 @@ def generate_data(config):
   dmrg.solve(**config.dmrg.solve_kwargs)
   mps = dmrg.state.copy()
   mps = mps.canonize(0)  # canonicalize MPS.
+  # TODO(YT): add dmrg data analysis.
 
   # Running data generation
   qtn.contraction.set_tensor_linop_backend('jax')


### PR DESCRIPTION
Changes:
1) I defined a helper function to construct the sweep parameters (line 14)
2) Now the config files takes in `sweep_fn_dict ` and select the right one by name, this enables running different sweep without changing the config file explicitly. 
Let me know if you have suggestions/comments on the above too, possibly a quick review @kochkov92 
I'm also hoping to be able to select `sampling_method` using --config.sampling_method. But currently this will mess up the names, unless I explicitly build `sweep_fn_dict ` for each `sampling_method`